### PR TITLE
Don't unmount/remount during a search but just move elements

### DIFF
--- a/src/components/AccountsPage/AccountGridItem/index.js
+++ b/src/components/AccountsPage/AccountGridItem/index.js
@@ -16,6 +16,7 @@ import IconAccountSettings from '../../../icons/AccountSettings'
 import ContextMenuItem from '../../ContextMenu/ContextMenuItem'
 
 type Props = {
+  hidden?: boolean,
   account: Account,
   onClick: Account => void,
   range: PortfolioRange,
@@ -51,35 +52,33 @@ class AccountCard extends PureComponent<Props> {
   ]
 
   render() {
-    const { account, range, ...props } = this.props
+    const { account, range, hidden, ...props } = this.props
     return (
       <ContextMenuItem items={this.contextMenuItems}>
-        <Box>
-          <Card
-            {...props}
-            style={{ cursor: 'pointer' }}
-            p={20}
-            onClick={this.onClick}
-            data-e2e="dashboard_AccountCardWrapper"
-          >
-            <Box flow={4}>
-              <AccountCardHeader account={account} />
-              <Bar size={1} color="fog" />
-              <Box justifyContent="center">
-                <FormattedVal
-                  alwaysShowSign={false}
-                  animateTicker={false}
-                  ellipsis
-                  color="dark"
-                  unit={account.unit}
-                  showCode
-                  val={account.balance}
-                />
-              </Box>
+        <Card
+          {...props}
+          style={{ cursor: 'pointer', display: hidden && 'none' }}
+          p={20}
+          onClick={this.onClick}
+          data-e2e="dashboard_AccountCardWrapper"
+        >
+          <Box flow={4}>
+            <AccountCardHeader account={account} />
+            <Bar size={1} color="fog" />
+            <Box justifyContent="center">
+              <FormattedVal
+                alwaysShowSign={false}
+                animateTicker={false}
+                ellipsis
+                color="dark"
+                unit={account.unit}
+                showCode
+                val={account.balance}
+              />
             </Box>
-            <AccountCardBody account={account} range={range} />
-          </Card>
-        </Box>
+          </Box>
+          <AccountCardBody account={account} range={range} />
+        </Card>
       </ContextMenuItem>
     )
   }

--- a/src/components/AccountsPage/AccountList/GridBody.js
+++ b/src/components/AccountsPage/AccountList/GridBody.js
@@ -8,7 +8,8 @@ import AccountCardPlaceholder from '../AccountGridItem/Placeholder'
 import AccountCard from '../AccountGridItem'
 
 type Props = {
-  accounts: Account[],
+  visibleAccounts: Account[],
+  hiddenAccounts: Account[],
   onAccountClick: Account => void,
   range: PortfolioRange,
 }
@@ -21,14 +22,23 @@ const GridBox = styled(Box)`
 
 class GridBody extends PureComponent<Props> {
   render() {
-    const { accounts, range, onAccountClick, ...rest } = this.props
+    const { visibleAccounts, hiddenAccounts, range, onAccountClick, ...rest } = this.props
 
     return (
       <GridBox {...rest}>
-        {accounts.map(account => (
+        {visibleAccounts.map(account => (
           <AccountCard key={account.id} account={account} range={range} onClick={onAccountClick} />
         ))}
-        <AccountCardPlaceholder key={'placeholder'} />
+        <AccountCardPlaceholder key="placeholder" />
+        {hiddenAccounts.map(account => (
+          <AccountCard
+            hidden
+            key={account.id}
+            account={account}
+            range={range}
+            onClick={onAccountClick}
+          />
+        ))}
       </GridBox>
     )
   }

--- a/src/components/AccountsPage/AccountList/ListBody.js
+++ b/src/components/AccountsPage/AccountList/ListBody.js
@@ -7,20 +7,24 @@ import AccountItem from '../AccountRowItem'
 import AccountItemPlaceholder from '../AccountRowItem/Placeholder'
 
 type Props = {
-  accounts: Account[],
+  visibleAccounts: Account[],
+  hiddenAccounts: Account[],
   onAccountClick: Account => void,
   range: PortfolioRange,
 }
 
 class ListBody extends PureComponent<Props> {
   render() {
-    const { accounts, range, onAccountClick } = this.props
+    const { visibleAccounts, hiddenAccounts, range, onAccountClick } = this.props
     return (
       <Box>
-        {accounts.map(item => (
+        {visibleAccounts.map(item => (
           <AccountItem key={item.id} account={item} range={range} onClick={onAccountClick} />
         ))}
         <AccountItemPlaceholder />
+        {hiddenAccounts.map(item => (
+          <AccountItem hidden key={item.id} account={item} range={range} onClick={onAccountClick} />
+        ))}
       </Box>
     )
   }

--- a/src/components/AccountsPage/AccountList/index.js
+++ b/src/components/AccountsPage/AccountList/index.js
@@ -40,11 +40,21 @@ class AccountList extends Component<Props, State> {
     const isUsingCards = this.state.mode === 'card'
     const Body = isUsingCards ? GridBody : ListBody
 
-    const filteredAccounts = accounts.filter(account =>
-      `${account.currency.ticker}|${account.currency.name}|${account.name}`
-        .toLowerCase()
-        .includes(search.toLowerCase()),
-    )
+    const visibleAccounts = []
+    const hiddenAccounts = []
+    for (let i = 0; i < accounts.length; i++) {
+      const account = accounts[i]
+      if (
+        !search ||
+        `${account.currency.ticker}|${account.currency.name}|${account.name}`
+          .toLowerCase()
+          .includes(search.toLowerCase())
+      ) {
+        visibleAccounts.push(account)
+      } else {
+        hiddenAccounts.push(account)
+      }
+    }
 
     return (
       <Box flow={4} style={{ cursor: 'pointer' }}>
@@ -61,7 +71,8 @@ class AccountList extends Component<Props, State> {
           horizontal
           data-e2e="dashboard_AccountList"
           range={range}
-          accounts={filteredAccounts}
+          visibleAccounts={visibleAccounts}
+          hiddenAccounts={hiddenAccounts}
           onAccountClick={onAccountClick}
         />
       </Box>

--- a/src/components/AccountsPage/AccountRowItem/index.js
+++ b/src/components/AccountsPage/AccountRowItem/index.js
@@ -22,6 +22,7 @@ import { MODAL_RECEIVE, MODAL_SEND, MODAL_SETTINGS_ACCOUNT } from '../../../conf
 type Props = {
   account: Account,
   onClick: Account => void,
+  hidden?: boolean,
   range: PortfolioRange,
   openModal: Function,
 }
@@ -55,36 +56,34 @@ class AccountRowItem extends PureComponent<Props> {
   ]
 
   render() {
-    const { account, range } = this.props
+    const { account, range, hidden } = this.props
     return (
       <ContextMenuItem items={this.contextMenuItems}>
-        <Box>
-          <GenericBox flex={1} onClick={this.onClick}>
-            <Box horizontal ff="Open Sans|SemiBold" flow={3} flex="30%" alignItems="center">
-              <Box
-                alignItems="center"
-                justifyContent="center"
-                style={{ color: account.currency.color }}
-              >
-                <CryptoCurrencyIcon currency={account.currency} size={20} />
-              </Box>
-              <Box grow>
-                <Box style={{ textTransform: 'uppercase' }} fontSize={9} color="graphite">
-                  {account.currency.name}
-                </Box>
-                <Ellipsis fontSize={12} color="dark">
-                  {account.name}
-                </Ellipsis>
-              </Box>
+        <GenericBox style={{ display: hidden && 'none' }} flex={1} onClick={this.onClick}>
+          <Box horizontal ff="Open Sans|SemiBold" flow={3} flex="30%" alignItems="center">
+            <Box
+              alignItems="center"
+              justifyContent="center"
+              style={{ color: account.currency.color }}
+            >
+              <CryptoCurrencyIcon currency={account.currency} size={20} />
             </Box>
-            <Box flex="10%">
-              <AccountSyncStatusIndicator accountId={account.id} account={account} />
+            <Box grow>
+              <Box style={{ textTransform: 'uppercase' }} fontSize={9} color="graphite">
+                {account.currency.name}
+              </Box>
+              <Ellipsis fontSize={12} color="dark">
+                {account.name}
+              </Ellipsis>
             </Box>
-            <Balance flex="35%" account={account} />
-            <Countervalue flex="15%" account={account} range={range} />
-            <Delta flex="10%" account={account} range={range} />
-          </GenericBox>
-        </Box>
+          </Box>
+          <Box flex="10%">
+            <AccountSyncStatusIndicator accountId={account.id} account={account} />
+          </Box>
+          <Balance flex="35%" account={account} />
+          <Countervalue flex="15%" account={account} range={range} />
+          <Delta flex="10%" account={account} range={range} />
+        </GenericBox>
       </ContextMenuItem>
     )
   }


### PR DESCRIPTION
instead of asking the DOM to unmount and remount later the elements, we just hide the elements and move them at the end. This will be a smaller update for the DOM.

there is still an improvement to do btw on that: we could move the hidden into an higher level so the inside of each component don't even need to re-render but i think it's going to be fine for now (we'll test in prod mode too)