### PR TITLE
LL-6516 - Implement reactive route logic based on path + History integration

### DIFF
--- a/src/renderer/Default.js
+++ b/src/renderer/Default.js
@@ -145,7 +145,7 @@ export default function Default() {
                           path="/asset/:assetId+"
                           render={(props: any) => <Asset {...props} />}
                         />
-                        <Route path="/swap" render={props => <SwapComponent {...props} />} exact />
+                        <Route path="/swap" render={props => <SwapComponent {...props} />} />
                       </Switch>
                     </Page>
                     <Drawer />

--- a/src/renderer/screens/exchange/Swap2/Form/FormSelectors/FromRow.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSelectors/FromRow.js
@@ -39,7 +39,7 @@ function FromRow({ fromAmount, setFromAmount, fromAccount, setFromAccount, t }: 
         color={"palette.text.shade40"}
       >
         <FormLabel>
-          <Trans i18nKey="swap.form.from.title" />
+          <Trans i18nKey="swap2.form.from.title" />
         </FormLabel>
         <Box horizontal alignItems="center">
           <Text marginRight={1} fontWeight="500">

--- a/src/renderer/screens/exchange/Swap2/Form/FormSelectors/ToRow.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSelectors/ToRow.js
@@ -26,7 +26,7 @@ export default function ToRow({ toCurrency, setToCurrency, toAmount, setToAmount
     <>
       <Box horizontal mb="8px" color={"palette.text.shade40"} fontSize={3}>
         <FormLabel>
-          <Trans i18nKey="swap.form.to.title" />
+          <Trans i18nKey="swap2.form.to.title" />
         </FormLabel>
       </Box>
       <Box horizontal>

--- a/src/renderer/screens/exchange/Swap2/Form/index.js
+++ b/src/renderer/screens/exchange/Swap2/Form/index.js
@@ -19,9 +19,11 @@ const summaryMockedData = {
 };
 
 const Wrapper: ThemedComponent<{}> = styled(Box).attrs({
-  p: 20,
+  pt: 36,
+  pb: 20,
 })`
   row-gap: 1.75rem;
+  max-width: 27.5rem;
 `;
 
 const Button = styled(ButtonBase)`

--- a/src/renderer/screens/exchange/Swap2/History/History.js
+++ b/src/renderer/screens/exchange/Swap2/History/History.js
@@ -2,7 +2,7 @@
 
 import { remote, ipcRenderer } from "electron";
 import React, { useMemo, useEffect, useState, useCallback } from "react";
-import { Trans } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import { useSelector, useDispatch } from "react-redux";
 import { accountsSelector } from "~/renderer/reducers/accounts";
 import OperationRow from "~/renderer/screens/exchange/swap/History/OperationRow";
@@ -55,6 +55,7 @@ const History = () => {
   const [exporting, setExporting] = useState(false);
   const [mappedSwapOperations, setMappedSwapOperations] = useState<?(SwapHistorySection[])>(null);
   const dispatch = useDispatch();
+  const { t } = useTranslation();
 
   const onExportOperations = useCallback(() => {
     async function asyncExport() {
@@ -140,7 +141,7 @@ const History = () => {
           <IconDownloadCloud size={16} />
           <Text ml={1} ff="Inter|Regular" fontSize={3}>
             <FakeLink onClick={exporting ? undefined : onExportOperations}>
-              {exporting ? "Exporting..." : "Export operations"}
+              {exporting ? t("swap2.history.exporting") : t("swap2.history.export")}
             </FakeLink>
           </Text>
         </ExportOperationsWrapper>
@@ -149,9 +150,7 @@ const History = () => {
         mappedSwapOperations.length ? (
           <Box>
             <Head px={20} py={16}>
-              <Alert type="primary">
-                <Trans i18nKey="swap.history.disclaimer" />
-              </Alert>
+              <Alert type="primary">{t("swap2.history.disclaimer")}</Alert>
             </Head>
             {mappedSwapOperations.map(section => (
               <>

--- a/src/renderer/screens/exchange/Swap2/History/History.js
+++ b/src/renderer/screens/exchange/Swap2/History/History.js
@@ -1,0 +1,181 @@
+// @flow
+
+import { remote, ipcRenderer } from "electron";
+import React, { useMemo, useEffect, useState, useCallback } from "react";
+import { Trans } from "react-i18next";
+import { useSelector, useDispatch } from "react-redux";
+import { accountsSelector } from "~/renderer/reducers/accounts";
+import OperationRow from "~/renderer/screens/exchange/swap/History/OperationRow";
+import { operationStatusList } from "@ledgerhq/live-common/lib/exchange/swap";
+import getCompleteSwapHistory from "@ledgerhq/live-common/lib/exchange/swap/getCompleteSwapHistory";
+import updateAccountSwapStatus from "@ledgerhq/live-common/lib/exchange/swap/updateAccountSwapStatus";
+import type { SwapHistorySection } from "@ledgerhq/live-common/lib/exchange/swap/types";
+import { flattenAccounts } from "@ledgerhq/live-common/lib/account";
+import { mappedSwapOperationsToCSV } from "@ledgerhq/live-common/lib/exchange/swap/csvExport";
+import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
+import useInterval from "~/renderer/hooks/useInterval";
+import Text from "~/renderer/components/Text";
+import Box from "~/renderer/components/Box";
+import Alert from "~/renderer/components/Alert";
+import SectionTitle from "~/renderer/components/OperationsList/SectionTitle";
+import { FakeLink } from "~/renderer/components/Link";
+import moment from "moment";
+import styled from "styled-components";
+import IconDownloadCloud from "~/renderer/icons/DownloadCloud";
+import { setDrawer } from "~/renderer/drawers/Provider";
+import SwapOperationDetails from "~/renderer/drawers/SwapOperationDetails";
+import HistoryLoading from "./HistoryLoading";
+import HistoryPlaceholder from "./HistoryPlaceholder";
+
+const Head = styled(Box)`
+  border-bottom: 1px solid ${p => p.theme.colors.palette.divider};
+`;
+
+const ExportOperationsWrapper = styled(Box)`
+  color: ${p => p.theme.colors.palette.primary.main};
+  align-items: center;
+  z-index: 10;
+`;
+
+const exportOperations = async (
+  path: { canceled: boolean, filePath: string },
+  csv: string,
+  callback?: () => void,
+) => {
+  try {
+    const res = await ipcRenderer.invoke("export-operations", path, csv);
+    if (res && callback) {
+      callback();
+    }
+  } catch (error) {}
+};
+
+const History = () => {
+  const accounts = useSelector(accountsSelector);
+  const [exporting, setExporting] = useState(false);
+  const [mappedSwapOperations, setMappedSwapOperations] = useState<?(SwapHistorySection[])>(null);
+  const dispatch = useDispatch();
+
+  const onExportOperations = useCallback(() => {
+    async function asyncExport() {
+      const path = await remote.dialog.showSaveDialog({
+        title: "Exported swap history",
+        defaultPath: `ledgerlive-swap-history-${moment().format("YYYY.MM.DD")}.csv`,
+        filters: [
+          {
+            name: "All Files",
+            extensions: ["csv"],
+          },
+        ],
+      });
+
+      if (path && mappedSwapOperations) {
+        exportOperations(path, mappedSwapOperationsToCSV(mappedSwapOperations), () =>
+          setExporting(false),
+        );
+      }
+    }
+    if (!exporting) {
+      asyncExport()
+        .catch(e => {
+          console.log({ e });
+        })
+        .then(() => {
+          setExporting(false);
+        });
+    }
+  }, [exporting, mappedSwapOperations]);
+
+  useEffect(() => {
+    (async function asyncGetCompleteSwapHistory() {
+      if (!accounts) return;
+      const sections = await getCompleteSwapHistory(flattenAccounts(accounts));
+      setMappedSwapOperations(sections);
+    })();
+  }, [accounts]);
+
+  const updateSwapStatus = useCallback(() => {
+    let cancelled = false;
+    async function fetchUpdatedSwapStatus() {
+      const updatedAccounts = await Promise.all(accounts.map(updateAccountSwapStatus));
+      if (!cancelled) {
+        updatedAccounts.filter(Boolean).forEach(account => {
+          dispatch(updateAccountWithUpdater(account.id, a => account));
+        });
+      }
+    }
+
+    fetchUpdatedSwapStatus();
+    return () => (cancelled = true);
+  }, [accounts, dispatch]);
+
+  const hasPendingSwapOperations = useMemo(() => {
+    if (mappedSwapOperations) {
+      for (const section of mappedSwapOperations) {
+        for (const swapOperation of section.data) {
+          if (operationStatusList.pending.includes(swapOperation.status)) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }, [mappedSwapOperations]);
+
+  useInterval(() => {
+    if (hasPendingSwapOperations) {
+      updateSwapStatus();
+    }
+  }, 10000);
+
+  const openSwapOperationDetailsModal = useCallback(
+    mappedSwapOperation => setDrawer(SwapOperationDetails, { mappedSwapOperation }),
+    [],
+  );
+
+  return (
+    <Box p={20}>
+      <Box horizontal flow={2} alignItems="center" justifyContent="flex-end">
+        <ExportOperationsWrapper horizontal>
+          <IconDownloadCloud size={16} />
+          <Text ml={1} ff="Inter|Regular" fontSize={3}>
+            <FakeLink onClick={exporting ? undefined : onExportOperations}>
+              {exporting ? "Exporting..." : "Export operations"}
+            </FakeLink>
+          </Text>
+        </ExportOperationsWrapper>
+      </Box>
+      {mappedSwapOperations ? (
+        mappedSwapOperations.length ? (
+          <Box>
+            <Head px={20} py={16}>
+              <Alert type="primary">
+                <Trans i18nKey="swap.history.disclaimer" />
+              </Alert>
+            </Head>
+            {mappedSwapOperations.map(section => (
+              <>
+                <SectionTitle day={section.day} />
+                <Box>
+                  {section.data.map(mappedSwapOperation => (
+                    <OperationRow
+                      key={mappedSwapOperation.swapId}
+                      mappedSwapOperation={mappedSwapOperation}
+                      openSwapOperationDetailsModal={openSwapOperationDetailsModal}
+                    />
+                  ))}
+                </Box>
+              </>
+            ))}
+          </Box>
+        ) : (
+          <HistoryPlaceholder />
+        )
+      ) : (
+        <HistoryLoading />
+      )}
+    </Box>
+  );
+};
+
+export default History;

--- a/src/renderer/screens/exchange/Swap2/History/HistoryLoading.js
+++ b/src/renderer/screens/exchange/Swap2/History/HistoryLoading.js
@@ -1,0 +1,12 @@
+// @flow
+import React from "react";
+import Box from "~/renderer/components/Box/Box";
+import BigSpinner from "~/renderer/components/BigSpinner";
+
+const HistoryLoading = () => (
+  <Box flex={1} alignItems="center" justifyContent="center">
+    <BigSpinner size={50} />
+  </Box>
+);
+
+export default HistoryLoading;

--- a/src/renderer/screens/exchange/Swap2/History/HistoryPlaceholder.js
+++ b/src/renderer/screens/exchange/Swap2/History/HistoryPlaceholder.js
@@ -1,0 +1,32 @@
+// @flow
+import React from "react";
+import Box from "~/renderer/components/Box/Box";
+import Text from "~/renderer/components/Text";
+import { useTranslation } from "react-i18next";
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
+import styled from "styled-components";
+
+const Wrapper: ThemedComponent<{}> = styled(Box).attrs(() => ({
+  justifyContent: "center",
+  alignItems: "center",
+}))`
+  min-height: 438px;
+  row-gap: 5px;
+`;
+
+const HistoryPlaceholder = () => {
+  const { t } = useTranslation();
+
+  return (
+    <Wrapper>
+      <Text ff="Inter|SemiBold" fontSize={16} color="palette.text.shade100">
+        {t("swap.history.empty.title")}
+      </Text>
+      <Text ff="Inter|Regular" fontSize={12} color="palette.text.shade50">
+        {t("swap.history.empty.description")}
+      </Text>
+    </Wrapper>
+  );
+};
+
+export default HistoryPlaceholder;

--- a/src/renderer/screens/exchange/Swap2/History/HistoryPlaceholder.js
+++ b/src/renderer/screens/exchange/Swap2/History/HistoryPlaceholder.js
@@ -20,10 +20,10 @@ const HistoryPlaceholder = () => {
   return (
     <Wrapper>
       <Text ff="Inter|SemiBold" fontSize={16} color="palette.text.shade100">
-        {t("swap.history.empty.title")}
+        {t("swap2.history.empty.title")}
       </Text>
       <Text ff="Inter|Regular" fontSize={12} color="palette.text.shade50">
-        {t("swap.history.empty.description")}
+        {t("swap2.history.empty.description")}
       </Text>
     </Wrapper>
   );

--- a/src/renderer/screens/exchange/Swap2/History/OperationRow.js
+++ b/src/renderer/screens/exchange/Swap2/History/OperationRow.js
@@ -1,0 +1,180 @@
+// @flow
+
+import Box from "~/renderer/components/Box";
+import Text from "~/renderer/components/Text";
+import FormattedVal from "~/renderer/components/FormattedVal";
+import {
+  getAccountCurrency,
+  getAccountUnit,
+  getAccountName,
+} from "@ledgerhq/live-common/lib/account";
+import React from "react";
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
+import styled from "styled-components";
+import CryptoCurrencyIcon from "~/renderer/components/CryptoCurrencyIcon";
+import Ellipsis from "~/renderer/components/Ellipsis";
+import IconArrowRight from "~/renderer/icons/ArrowRight";
+import IconSwap from "~/renderer/icons/Swap";
+
+import { rgba } from "~/renderer/styles/helpers";
+import type { MappedSwapOperation } from "@ledgerhq/live-common/lib/exchange/swap/types";
+import { operationStatusList } from "@ledgerhq/live-common/lib/exchange/swap";
+import Tooltip from "~/renderer/components/Tooltip";
+import IconClock from "~/renderer/icons/Clock";
+import FormattedDate from "~/renderer/components/FormattedDate";
+
+export const getStatusColor = (status: string, theme: any) => {
+  if (operationStatusList.pending.includes(status)) {
+    return status === "hold" ? theme.colors.orange : theme.colors.wallet;
+  } else if (operationStatusList.finishedOK.includes(status)) {
+    return theme.colors.positiveGreen;
+  } else if (operationStatusList.finishedKO.includes(status)) {
+    return theme.colors.alertRed;
+  } else {
+    return theme.colors.palette.shade50;
+  }
+};
+
+const Status: ThemedComponent<{}> = styled.div`
+  height: 24px;
+  width: 24px;
+  display: flex;
+  position: relative;
+  align-items: center;
+  justify-content: center;
+  border-radius: 24px;
+  background: ${p => rgba(getStatusColor(p.status, p.theme), 0.1)};
+  & > * {
+    color: ${p => getStatusColor(p.status, p.theme)};
+  }
+`;
+
+const WrapperClock: ThemedComponent<{}> = styled(Box).attrs(() => ({
+  bg: "palette.background.paper",
+  color: "palette.text.shade60",
+}))`
+  border-radius: 50%;
+  position: absolute;
+  bottom: -4px;
+  right: -4px;
+  padding: 1px;
+`;
+
+const Row: ThemedComponent<{}> = styled(Box)`
+  border-bottom: 1px solid ${p => p.theme.colors.palette.divider};
+  height: 68px;
+  opacity: ${p => (p.isOptimistic || !p.toExists ? 0.5 : 1)};
+  cursor: pointer;
+
+  &:hover {
+    background: ${p => rgba(p.theme.colors.wallet, 0.04)};
+  }
+
+  padding: 24px;
+  & > *:nth-child(2) {
+    flex: 10%;
+  }
+  & > *:nth-child(6) {
+    flex: 20%;
+  }
+  & > *:nth-child(3),
+  & > *:nth-child(5) {
+    flex: 20%;
+  }
+`;
+
+const OperationRow = ({
+  mappedSwapOperation,
+  openSwapOperationDetailsModal,
+}: {
+  mappedSwapOperation: MappedSwapOperation,
+  openSwapOperationDetailsModal: MappedSwapOperation => void,
+}) => {
+  const {
+    fromAccount,
+    toAccount,
+    fromAmount,
+    toAmount,
+    provider,
+    swapId,
+    operation,
+    status,
+    toExists,
+  } = mappedSwapOperation;
+  const fromCurrency = getAccountCurrency(fromAccount);
+  const toCurrency = getAccountCurrency(toAccount);
+
+  return (
+    <Row
+      className={"swap-history-row"}
+      toExists={toExists}
+      horizontal
+      key={swapId}
+      alignItems={"center"}
+      onClick={() => openSwapOperationDetailsModal(mappedSwapOperation)}
+    >
+      <Tooltip content={<span style={{ textTransform: "capitalize" }}>{status}</span>}>
+        <Status status={status}>
+          <IconSwap size={12} />
+          {operationStatusList.pending.includes(status) ? (
+            <WrapperClock>
+              <IconClock size={10} />
+            </WrapperClock>
+          ) : null}
+        </Status>
+      </Tooltip>
+      <Box ml={24}>
+        <Text
+          ff={"Inter|SemiBold"}
+          color={"palette.text.shade100"}
+          style={{ textTransform: "capitalize" }}
+          fontSize={3}
+        >
+          {provider}
+        </Text>
+        <Text ff={"Inter|Regular"} color={"palette.text.shade50"} fontSize={3}>
+          <FormattedDate date={operation.date} format="HH:mm" />
+        </Text>
+      </Box>
+      <Box horizontal mx={20}>
+        <Box alignItems="center" justifyContent="center">
+          <CryptoCurrencyIcon size={16} currency={fromCurrency} />
+        </Box>
+        <Tooltip delay={1200} content={getAccountName(fromAccount)}>
+          <Ellipsis ff="Inter|SemiBold" ml={1} color="palette.text.shade100" fontSize={3}>
+            {getAccountName(fromAccount)}
+          </Ellipsis>
+        </Tooltip>
+      </Box>
+      <Box color={"palette.text.shade30"}>
+        <IconArrowRight size={16} />
+      </Box>
+      <Box horizontal mx={20}>
+        <Box alignItems="center" justifyContent="center">
+          <CryptoCurrencyIcon size={16} currency={toCurrency} />
+        </Box>
+        <Tooltip delay={1200} content={getAccountName(toAccount)}>
+          <Ellipsis ff="Inter|SemiBold" ml={1} color="palette.text.shade100" fontSize={3}>
+            {getAccountName(toAccount)}
+          </Ellipsis>
+        </Tooltip>
+      </Box>
+      <Box alignItems={"flex-end"} ml={20}>
+        <Text ff={"Inter|SemiBold"} fontSize={4}>
+          <FormattedVal alwaysShowSign val={toAmount} unit={getAccountUnit(toAccount)} showCode />
+        </Text>
+        <Text ff={"Inter|SemiBold"} fontSize={3}>
+          <FormattedVal
+            color="palette.text.shade60"
+            alwaysShowSign
+            val={fromAmount.times(-1)}
+            unit={getAccountUnit(fromAccount)}
+            showCode
+          />
+        </Text>
+      </Box>
+    </Row>
+  );
+};
+
+export default OperationRow;

--- a/src/renderer/screens/exchange/Swap2/History/index.js
+++ b/src/renderer/screens/exchange/Swap2/History/index.js
@@ -1,12 +1,1 @@
-import React from "react";
-import HistoryV1 from "../../swap/History";
-
-/*
- ** As History screen doesn't have a specific v2 yet, this component
- ** only import and return v1 of the history screen.
- ** For the moment, UI is broken and need to be fixed. I wait to discuss
- ** with the design team before fixing it.
- */
-const History = () => <HistoryV1 />;
-
-export default History;
+export { default } from "./History";

--- a/src/renderer/screens/exchange/Swap2/History/index.js
+++ b/src/renderer/screens/exchange/Swap2/History/index.js
@@ -1,0 +1,12 @@
+import React from "react";
+import HistoryV1 from "../../swap/History";
+
+/*
+ ** As History screen doesn't have a specific v2 yet, this component
+ ** only import and return v1 of the history screen.
+ ** For the moment, UI is broken and need to be fixed. I wait to discuss
+ ** with the design team before fixing it.
+ */
+const History = () => <HistoryV1 />;
+
+export default History;

--- a/src/renderer/screens/exchange/Swap2/Navbar/index.js
+++ b/src/renderer/screens/exchange/Swap2/Navbar/index.js
@@ -1,0 +1,50 @@
+// @flow
+import React, { useMemo } from "react";
+
+import { useLocation, useHistory } from "react-router-dom";
+import TabBar from "~/renderer/components/TabBar";
+import { useTranslation } from "react-i18next";
+import TrackPage, { setTrackingSource } from "~/renderer/analytics/TrackPage";
+import styled from "styled-components";
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
+import swapRoutes from "./routes.json";
+
+const Nav: ThemedComponent<{}> = styled.nav`
+  background-color: ${p => p.theme.colors.palette.background.paper};
+
+  border-top-right-radius: 4px;
+  border-top-left-radius: 4px;
+`;
+
+/*
+ ** This component manages routing logic for swap screens and send
+ ** tracking data to analytics.
+ */
+const Navbar = () => {
+  const { pathname } = useLocation();
+  const history = useHistory();
+  const { t } = useTranslation();
+
+  const currentIndex = useMemo(() => {
+    return swapRoutes.findIndex(route => route.path === pathname);
+  }, [pathname]);
+
+  const tabs = useMemo(() => swapRoutes.map(route => t(route.title)), []);
+
+  const onWrappedTabChange = nextIndex => {
+    if (currentIndex === nextIndex) return;
+
+    const nextPathname = swapRoutes[nextIndex].path;
+    setTrackingSource("swap/navbar");
+    history.push({ pathname: nextPathname });
+  };
+
+  return (
+    <Nav>
+      <TrackPage category="swap" name={swapRoutes[currentIndex].name} />
+      <TabBar tabs={tabs} onIndexChange={onWrappedTabChange} index={currentIndex} />
+    </Nav>
+  );
+};
+
+export default Navbar;

--- a/src/renderer/screens/exchange/Swap2/Navbar/routes.json
+++ b/src/renderer/screens/exchange/Swap2/Navbar/routes.json
@@ -1,0 +1,4 @@
+[
+  { "name": "swap", "path": "/swap", "title": "swap2.tabs.exchange" },
+  { "name": "history", "path": "/swap/history", "title": "swap2.tabs.history" }
+]

--- a/src/renderer/screens/exchange/Swap2/index.js
+++ b/src/renderer/screens/exchange/Swap2/index.js
@@ -11,13 +11,14 @@ import Box from "~/renderer/components/Box";
 
 const Body = styled(Box)`
   row-gap: 2px;
+  flex: 1;
 `;
 
 const Main = styled.main`
   display: flex;
   justify-content: center;
+  flex: 1;
 
-  padding: 2rem 0;
   background-color: ${p => p.theme.colors.palette.background.paper};
 
   border-bottom-right-radius: 4px;
@@ -26,7 +27,6 @@ const Main = styled.main`
 
   & > * {
     width: 100%;
-    max-width: 27.5rem;
   }
 `;
 

--- a/src/renderer/screens/exchange/Swap2/index.js
+++ b/src/renderer/screens/exchange/Swap2/index.js
@@ -36,7 +36,7 @@ const Swap2 = () => {
   return (
     <>
       <Text horizontal mb={20} ff="Inter|SemiBold" fontSize={7} color="palette.text.shade100">
-        {t("swap.title")}
+        {t("swap2.title")}
       </Text>
       <Body>
         <SwapNavbar />

--- a/src/renderer/screens/exchange/Swap2/index.js
+++ b/src/renderer/screens/exchange/Swap2/index.js
@@ -1,10 +1,17 @@
 // @flow
 import React from "react";
 import { useTranslation } from "react-i18next";
-import TrackPage from "~/renderer/analytics/TrackPage";
+import { Route } from "react-router-dom";
+import styled from "styled-components";
 import Text from "~/renderer/components/Text";
 import SwapForm from "./Form";
-import styled from "styled-components";
+import SwapHistory from "./History";
+import SwapNavbar from "./Navbar";
+import Box from "~/renderer/components/Box";
+
+const Body = styled(Box)`
+  row-gap: 2px;
+`;
 
 const Main = styled.main`
   display: flex;
@@ -28,13 +35,16 @@ const Swap2 = () => {
 
   return (
     <>
-      <TrackPage category="Swap" />
       <Text horizontal mb={20} ff="Inter|SemiBold" fontSize={7} color="palette.text.shade100">
         {t("swap.title")}
       </Text>
-      <Main>
-        <SwapForm />
-      </Main>
+      <Body>
+        <SwapNavbar />
+        <Main>
+          <Route path="/swap" render={props => <SwapForm {...props} />} exact />
+          <Route path="/swap/history" render={props => <SwapHistory {...props} />} exact />
+        </Main>
+      </Body>
     </>
   );
 };

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -203,6 +203,10 @@
     "disconnectButton": "Disconnect"
   },
   "swap2": {
+    "tabs": {
+      "exchange": "Exchange",
+      "history": "History"
+    },
     "form": {
       "details": {
         "label": {

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -203,6 +203,7 @@
     "disconnectButton": "Disconnect"
   },
   "swap2": {
+    "title": "Swap",
     "tabs": {
       "exchange": "Exchange",
       "history": "History"
@@ -224,9 +225,22 @@
         "noAccountCTA": "Add account"
       },
       "from": {
+        "title": "From",
         "max": "Max",
         "accountPlaceholder": "Select source"
+      },
+      "to": {
+        "title": "To"
       }
+    },
+    "history": {
+      "disclaimer": "Your swap desktop transactions are not synchronized with the Ledger Live mobile application",
+      "empty": {
+        "title": "Your previous swaps will appear here",
+        "description": "Either you have not made any swaps yet, or Ledger Live has been reset in the meantime."
+      },
+      "export": "Export operations",
+      "exporting": "Exporting..."
     }
   },
   "swap": {

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -267,23 +267,6 @@
       "title": "Choose a provider to swap crypto",
       "learnMore": "What is Swap?",
       "kycRequired": "KYC Required",
-      "wyre": {
-        "bullets": [
-          "US-only (soon Europe, Africa and Asia)",
-          "Multi coins and tokens",
-          "Centralized"
-        ]
-      },
-      "changelly": {
-        "bullets": ["BTC, ETH, USDT and 50+ others", "Multi-currency", "Centralized"]
-      },
-      "paraswap": {
-        "bullets": [
-          "Connect to 30+ DEXs (Uniswap, SushiSwap,...)",
-          "Ethereum & ERC20 tokens",
-          "Decentralized & Trustless"
-        ]
-      },
       "cta": "Continue",
       "kyc": {
         "notAvailable": "{{provider}} is unavailable in your location",


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
Implement reactive route logic based on path.

~Note that the UI for the history screens is currently broken. Have to discuss with the design to decide if we keep the exact same UI from v1 or if some changes are planned. However, logic works.~
**Edit**: UI fixed, at least for loading and placeholder screens. Have to take a look to the screen that list swap history in the future (doesn't have enough founds to make a swap at the moment when I'm writing)

### Type

Chore
<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

### Context

[LL-6516](https://ledgerhq.atlassian.net/browse/LL-6516)

~~Awaiting #11~~

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

Swap screens.

### Attachment 📹 📷 

<details>
<summary>Light/Dark mode general screen recording</summary>

https://user-images.githubusercontent.com/33158502/127011270-c70107d2-6e46-4593-8b36-aa2559803694.mov


</details>

<details>
<summary>Light/Dark mode - Loading history screen recording</summary>


https://user-images.githubusercontent.com/33158502/127012524-55420932-b602-496e-9582-c31282a806c9.mov




</details>


<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
